### PR TITLE
Deploy method update (For injections)

### DIFF
--- a/gwak/data/background.py
+++ b/gwak/data/background.py
@@ -64,41 +64,41 @@ def gwak_background(
                 g.create_dataset(ifo, data=strains[ifo])
 
 
-        bash_files = [] # List of omicron commands to excute in background.  
-        if omi_paras is not None:
+        # bash_files = [] # List of omicron commands to excute in background.  
+        # if omi_paras is not None:
             
-            for ifo, frametype in zip(ifos, frame_type):
+        #     for ifo, frametype in zip(ifos, frame_type):
 
-                create_lcs(
-                    ifo=ifo,
-                    frametype=f"{ifo}_{frametype}",
-                    start_time=seg_start,
-                    end_time=seg_end,
-                    output_dir= Path(omi_paras["out_dir"]) / f"Segs_{seg_num:05d}", 
-                    urltype="file"
-                )
+        #         create_lcs(
+        #             ifo=ifo,
+        #             frametype=f"{ifo}_{frametype}",
+        #             start_time=seg_start,
+        #             end_time=seg_end,
+        #             output_dir= Path(omi_paras["out_dir"]) / f"Segs_{seg_num:05d}", 
+        #             urltype="file"
+        #         )
 
-            bash_scripts = omicron_bashes(
-                ifos= ifos,
-                start_time=seg_start,
-                end_time=seg_end,
-                project_dir= Path(omi_paras["out_dir"]) / f"Segs_{seg_num:05d}",
-                # INI
-                q_range= omi_paras["q_range"],
-                frequency_range= omi_paras["frequency_range"],
-                frame_type= frame_type,
-                channels= channels,
-                cluster_dt= omi_paras["cluster_dt"],
-                sample_rate= sample_rate,
-                chunk_duration= omi_paras["chunk_duration"],
-                segment_duration= omi_paras["segment_duration"],
-                overlap_duration= omi_paras["overlap_duration"],
-                mismatch_max= omi_paras["mismatch_max"],
-                snr_threshold= omi_paras["snr_threshold"],
-            )
+        #     bash_scripts = omicron_bashes(
+        #         ifos= ifos,
+        #         start_time=seg_start,
+        #         end_time=seg_end,
+        #         project_dir= Path(omi_paras["out_dir"]) / f"Segs_{seg_num:05d}",
+        #         # INI
+        #         q_range= omi_paras["q_range"],
+        #         frequency_range= omi_paras["frequency_range"],
+        #         frame_type= frame_type,
+        #         channels= channels,
+        #         cluster_dt= omi_paras["cluster_dt"],
+        #         sample_rate= sample_rate,
+        #         chunk_duration= omi_paras["chunk_duration"],
+        #         segment_duration= omi_paras["segment_duration"],
+        #         overlap_duration= omi_paras["overlap_duration"],
+        #         mismatch_max= omi_paras["mismatch_max"],
+        #         snr_threshold= omi_paras["snr_threshold"],
+        #     )
 
-            for bash_script in bash_scripts:
-                bash_files.append(bash_script)
+        #     for bash_script in bash_scripts:
+        #         bash_files.append(bash_script)
 
 
             # with ThreadPoolExecutor(max_workers=8) as e: # 8 workers

--- a/gwak/data/config.yaml
+++ b/gwak/data/config.yaml
@@ -1,11 +1,18 @@
 ifos: ["H1", "L1"]
-state_flag: ["DCS-ANALYSIS_READY_C01:1", "DCS-ANALYSIS_READY_C01:1"] 
-channels: ["DCS-CALIB_STRAIN_CLEAN_C01", "DCS-CALIB_STRAIN_CLEAN_C01"]
-frame_type: ["HOFT_C01", "HOFT_C01"] # H & L (O3)>>> HOFT_C01
-ana_start: 1238166018
-ana_end: 1238170289 
+# state_flag: ["DCS-ANALYSIS_READY_C01:1", "DCS-ANALYSIS_READY_C01:1"] 
+# channels: ["DCS-CALIB_STRAIN_CLEAN_C01", "DCS-CALIB_STRAIN_CLEAN_C01"]
+# frame_type: ["HOFT_C01", "HOFT_C01"] # H & L (O3)>>> HOFT_C01
+# ana_start: 1238166018
+# ana_end: 1238170289 
+
+state_flag: ["DMT-ANALYSIS_READY:1", "DMT-ANALYSIS_READY:1"]
+channels: ["GDS-CALIB_STRAIN_CLEAN", "GDS-CALIB_STRAIN_CLEAN"]
+frame_type: ["HOFT_C00", "HOFT_C00"]
+ana_start: 1403964034
+ana_end: 1406556034
+
 sample_rate: 4096 
-save_dir:  ../output # Will have to implemt with class function that use enviroment variables. 
+save_dir:  ../output/O4_month_after_MDC_background/ # Will have to implemt with class function that use enviroment variables. 
 omi_paras:
   out_dir: "../output/omicron"
   q_range: [3.3166, 108.0]

--- a/gwak/data/time_slide.py
+++ b/gwak/data/time_slide.py
@@ -13,11 +13,11 @@ def generate_timeslide(
     sample_rate = 2048,
     highpass = 30,
     fftlength = 2,
-    kernel_length = 0.09765625,  # 0.09765625
+    kernel_length = 1,  # 0.09765625
     psd_length = 64,
-    data_dir = Path("/home/katya.govorkova/gwak2_background"),
-    whitened_dir = Path("/home/hongyin.chen/whiten_timeslide_short.h5"),
-    data_format = "hdf5",
+    data_dir = Path("/home/hongyin.chen/anti_gravity/gwak/gwak/output/O4_MDC_background_short"),
+    whitened_dir = Path("/home/hongyin.chen/whiten_timeslide_one_sec.h5"),
+    data_format = "h5",
     shifts = 2,
     ifos = ["H1", "L1"],
     device="cuda"
@@ -32,7 +32,6 @@ def generate_timeslide(
     splits = [psd_length * sample_rate, split_size]
 
     whitened_data = []
-    
     for shift in range(1, shifts + 1):
         for strain_file in data_dir.glob(f"*.{data_format}"):
             
@@ -47,7 +46,7 @@ def generate_timeslide(
                 # inference_sampling_rate=inference_sampling_rate,
                 inj_type=None,
             )
-            print(shift)
+            print(f"{shift = }")
             for idx, (bh_state, _) in enumerate(sequence):
                 if idx == (len(sequence) - 1):
                     continue
@@ -59,7 +58,7 @@ def generate_timeslide(
                 whitened = whitener(batch.double(), psds.double())
 
                 whitened_data.append(whitened)
-
+            print(whitened_data)
     whitened_data = torch.vstack(whitened_data)
     whitened_data = whitened_data.cpu().detach().numpy()
     with h5py.File(whitened_dir, "w") as g:

--- a/gwak/data/time_slide.py
+++ b/gwak/data/time_slide.py
@@ -1,0 +1,72 @@
+
+import torch
+import h5py
+from pathlib import Path
+
+from ml4gw.transforms import SpectralDensity, Whiten
+
+from background_utils import Sequence
+
+
+def generate_timeslide(
+    fduration = 1,
+    sample_rate = 2048,
+    highpass = 30,
+    fftlength = 2,
+    kernel_length = 0.09765625,  # 0.09765625
+    psd_length = 64,
+    data_dir = Path("/home/katya.govorkova/gwak2_background"),
+    whitened_dir = Path("/home/hongyin.chen/whiten_timeslide_short.h5"),
+    data_format = "hdf5",
+    shifts = 2,
+    ifos = ["H1", "L1"],
+    device="cuda"
+):
+
+    kernel_size = int((psd_length + kernel_length + fduration) * sample_rate)
+
+    whitener = Whiten(fduration, sample_rate, highpass).to(device)
+    spectral_density = SpectralDensity(sample_rate,fftlength,average='median').to(device)
+
+    split_size = int((kernel_length + fduration) * sample_rate)
+    splits = [psd_length * sample_rate, split_size]
+
+    whitened_data = []
+    
+    for shift in range(1, shifts + 1):
+        for strain_file in data_dir.glob(f"*.{data_format}"):
+            
+            sequence = Sequence(
+                fname=strain_file,
+                data_format=data_format,
+                shifts=[0, shift],
+                # batch_size=batch_size,0
+                ifos=ifos,
+                kernel_size=kernel_size,
+                sample_rate=sample_rate,
+                # inference_sampling_rate=inference_sampling_rate,
+                inj_type=None,
+            )
+            print(shift)
+            for idx, (bh_state, _) in enumerate(sequence):
+                if idx == (len(sequence) - 1):
+                    continue
+                bh_state = torch.Tensor(bh_state).to(device)
+                # breakpoint()
+                psd_data, batch = torch.split(bh_state, splits, dim=-1)
+                psds = spectral_density(psd_data.double())
+                
+                whitened = whitener(batch.double(), psds.double())
+
+                whitened_data.append(whitened)
+
+    whitened_data = torch.vstack(whitened_data)
+    whitened_data = whitened_data.cpu().detach().numpy()
+    with h5py.File(whitened_dir, "w") as g:
+
+        g.create_dataset("data", data=whitened_data)
+        
+        
+if __name__ == "__main__":
+    
+    generate_timeslide()

--- a/gwak/deploy/deploy.smk
+++ b/gwak/deploy/deploy.smk
@@ -28,11 +28,11 @@ rule infer:
     output:
         artefact = directory('output/infer/{deploymodels}')
     shell:
-        'set -x; cd deploy; CUDA_VISIBLE_DEVICES=1 poetry run python \
+        'set -x; cd deploy; CUDA_VISIBLE_DEVICES=0 poetry run python \
         ../deploy/deploy/cli_infer.py --config ../{input.config} --project {params.cli}'
 
 rule export_all:
-    input: expand(rules.export.output, deploymodels='white_noise_burst')
+    input: expand(rules.export.output, deploymodels='bbh')
 
 rule infer_all:
-    input: expand(rules.infer.output, deploymodels='white_noise_burst')
+    input: expand(rules.infer.output, deploymodels='bbh')

--- a/gwak/deploy/deploy.smk
+++ b/gwak/deploy/deploy.smk
@@ -32,7 +32,7 @@ rule infer:
         ../deploy/deploy/cli_infer.py --config ../{input.config} --project {params.cli}'
 
 rule export_all:
-    input: expand(rules.export.output, deploymodels='bbh')
+    input: expand(rules.export.output, deploymodels='white_noise_burst')
 
 rule infer_all:
-    input: expand(rules.infer.output, deploymodels='bbh')
+    input: expand(rules.infer.output, deploymodels='white_noise_burst')

--- a/gwak/deploy/deploy/config/ccsn.yaml
+++ b/gwak/deploy/deploy/config/ccsn.yaml
@@ -1,7 +1,7 @@
 Andresen_2016 :
     [
         # "s11", 
-        "s20", # Burst
+        # "s20", # Burst
         "s20s", # Burst 
         # "s27", 
     ]
@@ -10,7 +10,7 @@ Andresen_2019 :
     [ 
         # "s15nr", 
         # "s15sr", 
-        "s15fr", # Burst
+        # "s15fr", # Burst
     ]
 
 OConnor_2018: 
@@ -19,7 +19,7 @@ OConnor_2018:
         # "mesa20_pert", 
         # "mesa20_LR", 
         # "mesa20_v_LR", 
-        "mesa20_pert_LR" # Burst 
+        # "mesa20_pert_LR" # Burst 
     ]
 
 Pan_2021: 

--- a/gwak/deploy/deploy/config/export.yaml
+++ b/gwak/deploy/deploy/config/export.yaml
@@ -2,10 +2,10 @@ project: white_noise_burst
 model_dir: /home/hongyin.chen/anti_gravity/gwak/gwak/output
 output_dir: /home/hongyin.chen/anti_gravity/gwak/gwak/output/export
 clean: True
-background_batch_size: 1
+background_batch_size: 2 # Fixed setting Channel 1 PSD estimeter Channel 2 Processing strain data 
 stride_batch_size: 256
 num_ifos: 2
-gwak_instances: 20
+gwak_instances: 5
 platform: TORCHSCRIPT
 # platform: ONNX
 psd_length: 64

--- a/gwak/deploy/deploy/config/export.yaml
+++ b/gwak/deploy/deploy/config/export.yaml
@@ -5,7 +5,7 @@ clean: True
 background_batch_size: 2 # Fixed setting Channel 1 PSD estimeter Channel 2 Processing strain data 
 stride_batch_size: 256
 num_ifos: 2
-gwak_instances: 5
+gwak_instances: 15
 platform: TORCHSCRIPT
 # platform: ONNX
 psd_length: 64
@@ -15,3 +15,4 @@ fftlength: 2
 sample_rate: 2048
 preproc_instances: 1
 inference_sampling_rate: 1
+# inference_sampling_rate: 10.24

--- a/gwak/deploy/deploy/config/infer.yaml
+++ b/gwak/deploy/deploy/config/infer.yaml
@@ -3,20 +3,21 @@ ifos: ["H1", "L1"]
 # fduration: 1
 # kernel_length: 0.09765625
 kernel_length: 1
-Tb: 86400
+Tb: 1800
 # Tb: 31536000
 batch_size: 1
 stride_batch_size: 256
 sample_rate: 2048
-# fname: /home/hongyin.chen/Data/GWAK_data/gwak_infer_data
-fname: /home/katya.govorkova/gwak2_background
+fname: /home/hongyin.chen/Data/GWAK_data/gwak_infer_data
+# fname: /home/katya.govorkova/gwak2_background
 ccsn_repo: /home/hongyin.chen/Data/3DCCSN_PREMIERE/Resampled_2048 # 1 kpc
 data_format: hdf5 # gwf
 shifts: [0, 1]
 project: white_noise_purst
 model_repo_dir: /home/hongyin.chen/anti_gravity/gwak/gwak/output/export
-image: hermes/tritonserver:23.01
+image: hermes/tritonserver:24.01
 result_dir: /home/hongyin.chen/anti_gravity/gwak/gwak/output/infer
-rate_limit: 40
+rate_limit: 1
 load_model_patients: 5
 inference_sampling_rate: 1
+# inj_type: None

--- a/gwak/deploy/deploy/config/infer.yaml
+++ b/gwak/deploy/deploy/config/infer.yaml
@@ -4,20 +4,23 @@ ifos: ["H1", "L1"]
 # kernel_length: 0.09765625
 kernel_length: 1
 Tb: 1800
+# Tb: 86400
+# Tb: 2592000
 # Tb: 31536000
 batch_size: 1
 stride_batch_size: 256
 sample_rate: 2048
 fname: /home/hongyin.chen/Data/GWAK_data/gwak_infer_data
+fname: /home/hongyin.chen/anti_gravity/gwak/gwak/output/O4_month_after_MDC_background
 # fname: /home/katya.govorkova/gwak2_background
 ccsn_repo: /home/hongyin.chen/Data/3DCCSN_PREMIERE/Resampled_2048 # 1 kpc
 data_format: hdf5 # gwf
 shifts: [0, 1]
 project: white_noise_purst
 model_repo_dir: /home/hongyin.chen/anti_gravity/gwak/gwak/output/export
-image: hermes/tritonserver:24.01
+image: hermes/tritonserver:23.01
 result_dir: /home/hongyin.chen/anti_gravity/gwak/gwak/output/infer
-rate_limit: 1
+rate_limit: 4
 load_model_patients: 5
 inference_sampling_rate: 1
 # inj_type: None

--- a/gwak/deploy/deploy/export.py
+++ b/gwak/deploy/deploy/export.py
@@ -34,7 +34,6 @@ def export(
     
     weights = model_dir / project / "model_JIT.pt"
     output_dir = output_dir / project
-    batch_size = background_batch_size * stride_batch_size
     kernel_size = int(kernel_length * sample_rate)
 
     with open(weights, "rb") as f:
@@ -55,7 +54,7 @@ def export(
         scale_model(gwak, gwak_instances)
 
     # input_shape = (batch_size, kernel_size, num_ifos) # Apply this for gwak_1
-    input_shape = (batch_size, num_ifos, kernel_size) 
+    input_shape = (stride_batch_size, num_ifos, kernel_size) 
     kwargs = {}
     if platform == qv.Platform.ONNX:
         kwargs["opset_version"] = 13

--- a/gwak/deploy/deploy/infer.py
+++ b/gwak/deploy/deploy/infer.py
@@ -35,9 +35,10 @@ def infer(
     model_repo_dir: Path,
     image: Path,
     result_dir: Path,
-    rate_limit: int = 20,
+    rate_limit: int=20,
     load_model_patients: int=10,
     inference_sampling_rate: float = 1,
+    # inj_type=None,
     **kwargs,
 ):
 
@@ -59,6 +60,7 @@ def infer(
     logging.info(f"    Data directory at {fname}")
 
     num_shifts, fnames, segments = get_shifts_meta_data(fname, Tb, shifts)
+    arguments=Path("deploy/triton_excution.py").resolve()
 
     serve_context = serve(
         model_repo_dir, 
@@ -95,14 +97,17 @@ def infer(
                     data_format=data_format,
                     shifts=_shifts,
                     batch_size=batch_size,
+                    stride_batch_size=stride_batch_size,
                     ifos=ifos,
                     kernel_size=kernel_size,
                     inference_sampling_rate=inference_sampling_rate,
+                    # inj_type=inj_type,
                 )
+
 
                 submit_file = make_subfile(
                     job_dir=job_dir,
-                    arguments=Path("deploy/triton_excution.py").resolve(),
+                    arguments=arguments,
                     config=config_file.resolve()
                 )
 

--- a/gwak/deploy/deploy/infer_data.py
+++ b/gwak/deploy/deploy/infer_data.py
@@ -91,7 +91,7 @@ class Sequence:
     def __iter__(self):
 
         # Check if this line will hide potential implmetation error! 
-        limiter = RateLimiter(max_calls=1, period=0.5)
+        limiter = RateLimiter(max_calls=1, period=0.1)
         bg_state = np.empty(self.state_shape, dtype=self.precision) 
         inj_state = None
 

--- a/gwak/deploy/deploy/libs/condor_tools.py
+++ b/gwak/deploy/deploy/libs/condor_tools.py
@@ -114,7 +114,7 @@ def condor_submit_with_rate_limit(
 
         # Check if we need to submit new jobs
         if len(job_status["Running"]) < rate_limit:
-            
+            # time.sleep(15)
             try: 
                 logging.info(f"Submitting {job_status['Waiting'][0]}")
                 job_id = submit_condor_job(sub_file=job_status["Waiting"][0])
@@ -125,7 +125,7 @@ def condor_submit_with_rate_limit(
                 continue
             except IndexError:
                 pass
-                
+
         time.sleep(10)
         # Check if any job is done
         result = subprocess.run("condor_q", capture_output=True, text=True)

--- a/gwak/deploy/deploy/libs/condor_tools.py
+++ b/gwak/deploy/deploy/libs/condor_tools.py
@@ -55,6 +55,7 @@ def make_infer_config(
     data_format: str,
     shifts:list,
     batch_size:int,
+    stride_batch_size:int,
     ifos:list,
     kernel_size:int,
     sample_rate=2048,

--- a/gwak/deploy/deploy/libs/ensemble.py
+++ b/gwak/deploy/deploy/libs/ensemble.py
@@ -44,7 +44,8 @@ def add_streaming_input_preprocessor(
 
     # _, _, *kernel_size = input.shape # batch_size, num_ifos, *kernel_size
     # # batch_size, *kernel_size, num_ifos  = input.shape # Apply for gwak1
-    background_batch_size * stride_batch_size
+    background_batch_size
+    # * stride_batch_size
     snapshotter = BackgroundSnapshotter(
         psd_length=psd_length,
         kernel_length=kernel_length,
@@ -57,8 +58,10 @@ def add_streaming_input_preprocessor(
     state_shape = (background_batch_size, num_ifos, snapshotter.state_size)
     input_shape = (background_batch_size, num_ifos, stride_batch_size * stride)
     logging.info(f"Snappshot kerenl shape: ")
-    logging.info(f"    Batch size: {state_shape[0]}")
+    logging.info(f"    Batch Size: {state_shape[0]}")
     logging.info(f"    Nums Ifo: {state_shape[1]}")
+    logging.info(f"    Input Update: {input_shape[-1]}")
+    logging.info(f"    State Size: {state_shape[-1]}")
     logging.info(f"    Sample Kernel: {state_shape[-1] + input_shape[-1]}")
     # state_shape = (background_batch_size, snapshotter.state_size, num_ifos) # Apply for gwak1
 

--- a/gwak/deploy/deploy/libs/infer_utils.py
+++ b/gwak/deploy/deploy/libs/infer_utils.py
@@ -96,7 +96,7 @@ def get_hp_hc_from_q2ij(
     return hp, hc
 
 
-def on_grid_pol_to_sim(quad_moment, sqrtnum):
+def on_grid_pol_to_sim(quad_moment, sqrtnum=16):
 
     CosTheta = np.linspace(-1, 1, sqrtnum)
     theta = np.arccos(CosTheta)

--- a/gwak/deploy/deploy/libs/infer_utils.py
+++ b/gwak/deploy/deploy/libs/infer_utils.py
@@ -15,6 +15,11 @@ from hermes.aeriel.client import InferenceClient
 
 
 
+EXTREME_CCSN = [
+    "Pan_2021/FR",
+    "Powell_2020/y20"
+]
+
 def get_ip_address() -> str:
     """
     Get the local nodes cluster-internal IP address

--- a/gwak/deploy/deploy/libs/whiten_utils.py
+++ b/gwak/deploy/deploy/libs/whiten_utils.py
@@ -93,7 +93,6 @@ class PsdEstimator(torch.nn.Module):
             X = X[-1] # Strain data is at axis=-1
 
         psds = self.spectral_density(background.double())
-        # psds = psds.transpose(0,1)
         return X, psds
 
 
@@ -151,14 +150,17 @@ class BatchWhitener(torch.nn.Module):
             )
         x, psd = self.psd_estimator(x)
         whitened = self.whitener(x.double(), psd)
+
         # unfold x and then put it into the expected shape.
         # Note that if x has both signal and background
         # batch elements, they will be interleaved along
         # the batch dimension after unfolding
-        x = unfold_windows(whitened, self.kernel_size, self.stride_size) # (batch, num_ifo, kernel_size)
-        x = x.reshape(-1, num_channels, self.kernel_size) # Apply this for gwak_1
+        # x = unfold_windows(whitened, self.kernel_size, self.stride_size) # (batch, num_ifo, kernel_size)
+        # x = x.reshape(-1, num_channels, self.kernel_size) # Apply this for gwak_1
         # x = x.reshape(-1, self.kernel_size, num_channels) # Apply this for gwak_1
         # whitened = whitened.transpose(1, 2) # Apply this for gwak_1
+        x = unfold_windows(whitened, self.kernel_size, self.stride_size)
+        x = x.reshape(-1, num_channels, self.kernel_size)
         if self.augmentor is not None:
             x = self.augmentor(x)
         if self.return_whitened:

--- a/gwak/deploy/deploy/triton_excution.py
+++ b/gwak/deploy/deploy/triton_excution.py
@@ -1,3 +1,4 @@
+import os
 import h5py
 import logging
 import time 
@@ -12,6 +13,11 @@ from infer_data import Sequence, CCSN_Waveform_Projector, load_h5_as_dict
 from deploy.libs import gwak_logger
 
 gwak_logger("log.log")
+
+EXTREME_CCSN = [
+    "Pan_2021/FR",
+    "Powell_2020/y20"
+]
 
 def run_infer(
     triton_server_ip: str,
@@ -31,8 +37,8 @@ def run_infer(
 
     inj_type=None # Set injection type manully
     client = InferenceClient(f"{triton_server_ip}:8001", gwak_streamer)
-
-    results = []
+    print(os.environ["CCSN_FILE"])
+    # results = [""]
     with client:
 
         sequence = Sequence(
@@ -46,25 +52,12 @@ def run_infer(
             inference_sampling_rate=inference_sampling_rate,
             inj_type=None,
         )
-        
-        projector = CCSN_Waveform_Projector(
-            ifos=["H1", "L1"],
-            sample_rate=2048,
-            sample_duration=stride_batch_size, 
-        )
-        
-        signals_dict = load_h5_as_dict(
-            chosen_signals="/home/hongyin.chen/anti_gravity/gwak/gwak/deploy/deploy/config/ccsn.yaml",
-            source_file="/home/hongyin.chen/Data/3DCCSN_PREMIERE/Resampled_2048"
-        )
-        
-        for i, (bh_state, inj_state) in enumerate(sequence):
+
+        for i, (bh_state, _) in enumerate(sequence):
 
             sequence_start = (i == 0)
             sequence_end = (i == (len(sequence) - 1))
-            logging.info(f"sequence_start = {sequence_start}")
-            logging.info(f"sequence_end = {sequence_end}")
-            logging.info(f" ")
+
             # Sending request to the triton server. 
             client.infer(
                 np.stack([bh_state, bh_state]),
@@ -73,40 +66,6 @@ def run_infer(
                 sequence_start=sequence_start,
                 sequence_end=sequence_end,
             )
-            
-            if inj_type is not None:
-                
-                # Should make the following as a function and called by the inj_type. 
-                # Or move this to Sequence inj iterator.
-                inj_state_copy = inj_state
-                for key_idx, key in enumerate(signals_dict.keys()):
-                    logging.info(f"Running {key} analysis")
-                    
-                    ccsne = projector(
-                        time = signals_dict[key][0],
-                        quad_moment = signals_dict[key][1] * 10,
-                        ori_theta=np.zeros(stride_batch_size),
-                        ori_phi=np.zeros(stride_batch_size),
-                        dec=np.zeros(stride_batch_size),
-                        psi=np.zeros(stride_batch_size),
-                        phi=np.zeros(stride_batch_size),
-                    )
-                    
-                    dis_grid_count = 3
-                    for grid_count, dis in enumerate(np.geomspace(1, 10, dis_grid_count)):
-                        ccsne = ccsne[:,:,3072:-1024] / dis
-                    
-                        for inj_idx, ccsn in enumerate(ccsne):
-                            
-                            inj_state_copy[:, (inj_idx)*sample_rate: (inj_idx + 1)*sample_rate] += ccsn  
-                            
-                            client.infer(
-                                np.stack([bh_state, inj_state_copy]),
-                                request_id=i,
-                                sequence_id=sequence_id + 1 + key_idx * dis_grid_count + grid_count,
-                                sequence_start=sequence_start,
-                                sequence_end=sequence_end,
-                            )
 
             # Retrieve response from the triton server. 
             result = client.get()

--- a/gwak/deploy/deploy/triton_excution.py
+++ b/gwak/deploy/deploy/triton_excution.py
@@ -1,6 +1,6 @@
 import h5py
 import logging
-
+import time 
 import numpy as np
 
 from typing import Union
@@ -8,7 +8,7 @@ from pathlib import Path
 from jsonargparse import ArgumentParser, ActionConfigFile
 
 from hermes.aeriel.client import InferenceClient
-from infer_data import Sequence
+from infer_data import Sequence, CCSN_Waveform_Projector, load_h5_as_dict
 from deploy.libs import gwak_logger
 
 gwak_logger("log.log")
@@ -21,15 +21,15 @@ def run_infer(
     data_format: str,
     shifts: list=[0.0, 1.0],
     batch_size:int=1,
+    stride_batch_size:int=256,
     ifos:list=["H1", "L1"],
     kernel_size:int=2048,
     sample_rate:int=2048,
     inference_sampling_rate:float=1,
-    # inj_type=None,
     **kwargs
 ):
 
-
+    inj_type=None # Set injection type manully
     client = InferenceClient(f"{triton_server_ip}:8001", gwak_streamer)
 
     results = []
@@ -47,31 +47,75 @@ def run_infer(
             inj_type=None,
         )
         
+        projector = CCSN_Waveform_Projector(
+            ifos=["H1", "L1"],
+            sample_rate=2048,
+            sample_duration=stride_batch_size, 
+        )
+        
+        signals_dict = load_h5_as_dict(
+            chosen_signals="/home/hongyin.chen/anti_gravity/gwak/gwak/deploy/deploy/config/ccsn.yaml",
+            source_file="/home/hongyin.chen/Data/3DCCSN_PREMIERE/Resampled_2048"
+        )
+        
         for i, (bh_state, inj_state) in enumerate(sequence):
 
             sequence_start = (i == 0)
             sequence_end = (i == (len(sequence) - 1))
-
+            logging.info(f"sequence_start = {sequence_start}")
+            logging.info(f"sequence_end = {sequence_end}")
+            logging.info(f" ")
             # Sending request to the triton server. 
             client.infer(
-                bh_state,
+                np.stack([bh_state, bh_state]),
                 request_id=i,
                 sequence_id=sequence_id,
                 sequence_start=sequence_start,
                 sequence_end=sequence_end,
             )
             
-            if inj_state is not None:
+            if inj_type is not None:
                 
-                print(inj_state)
+                # Should make the following as a function and called by the inj_type. 
+                # Or move this to Sequence inj iterator.
+                inj_state_copy = inj_state
+                for key_idx, key in enumerate(signals_dict.keys()):
+                    logging.info(f"Running {key} analysis")
+                    
+                    ccsne = projector(
+                        time = signals_dict[key][0],
+                        quad_moment = signals_dict[key][1] * 10,
+                        ori_theta=np.zeros(stride_batch_size),
+                        ori_phi=np.zeros(stride_batch_size),
+                        dec=np.zeros(stride_batch_size),
+                        psi=np.zeros(stride_batch_size),
+                        phi=np.zeros(stride_batch_size),
+                    )
+                    
+                    dis_grid_count = 3
+                    for grid_count, dis in enumerate(np.geomspace(1, 10, dis_grid_count)):
+                        ccsne = ccsne[:,:,3072:-1024] / dis
+                    
+                        for inj_idx, ccsn in enumerate(ccsne):
+                            
+                            inj_state_copy[:, (inj_idx)*sample_rate: (inj_idx + 1)*sample_rate] += ccsn  
+                            
+                            client.infer(
+                                np.stack([bh_state, inj_state_copy]),
+                                request_id=i,
+                                sequence_id=sequence_id + 1 + key_idx * dis_grid_count + grid_count,
+                                sequence_start=sequence_start,
+                                sequence_end=sequence_end,
+                            )
 
             # Retrieve response from the triton server. 
             result = client.get()
             while result is None:
                 result = client.get()
 
+
             results.append(result[0])
-        # Job Done leaving client 
+            # Job Done leaving client 
 
     results = np.stack(results)
     saving_dir = Path("../../inference_result")

--- a/gwak/deploy/deploy/triton_inj_excution.py
+++ b/gwak/deploy/deploy/triton_inj_excution.py
@@ -1,0 +1,149 @@
+import os
+import h5py
+import logging
+import time 
+import numpy as np
+
+from typing import Union
+from pathlib import Path
+from jsonargparse import ArgumentParser, ActionConfigFile
+
+from hermes.aeriel.client import InferenceClient
+from infer_data import Sequence, CCSN_Waveform_Projector, load_h5_as_dict
+from deploy.libs import gwak_logger
+
+gwak_logger("log.log")
+
+EXTREME_CCSN = [
+    "Pan_2021/FR",
+    "Powell_2020/y20"
+]
+
+def run_infer(
+    triton_server_ip: str,
+    gwak_streamer: str,
+    sequence_id: int,
+    strain_file: Union[str, Path],
+    data_format: str,
+    shifts: list=[0.0, 1.0],
+    batch_size:int=1,
+    stride_batch_size:int=256,
+    ifos:list=["H1", "L1"],
+    kernel_size:int=2048,
+    sample_rate:int=2048,
+    inference_sampling_rate:float=1,
+    **kwargs
+):
+    
+    sequence_kernel_size = kernel_size # Temporal setup to get over config setting
+    dis_grid_count = 4
+    one_side_pad_length = 0.5
+    kernel_length = 0.5
+    kernel_size = int(kernel_length * sample_rate)
+    os.getenv # Use this to get ccsn config file. 
+    inj_type=None # Set injection type manully
+    client = InferenceClient(f"{triton_server_ip}:8001", gwak_streamer)
+    print(os.getenv("CCSN_FILE"))
+    
+    with client:
+
+        sequence = Sequence(
+            fname=strain_file,
+            data_format=data_format,
+            shifts=shifts,
+            batch_size=batch_size,
+            ifos=ifos,
+            kernel_size=sequence_kernel_size,
+            sample_rate=sample_rate,
+            inference_sampling_rate=inference_sampling_rate,
+            inj_type=None,
+        )
+
+        signals_dict = load_h5_as_dict(
+            chosen_signals="/home/hongyin.chen/anti_gravity/gwak/gwak/deploy/deploy/config/ccsn.yaml",
+            source_file="/home/hongyin.chen/Data/3DCCSN_PREMIERE/Resampled_2048"
+        )
+
+        # No additional time shift
+        projector = CCSN_Waveform_Projector(
+            ifos=ifos,
+            sample_rate=sample_rate,
+            sample_duration=3, 
+        )
+
+        for key_idx, key in enumerate(signals_dict.keys()):
+            logging.info(f"Running {key} analysis")
+
+            # Initaizing distance setup
+            min_dis, max_dis = 0.5, 20
+            if key in EXTREME_CCSN: 
+                min_dis, max_dis = 5, 100
+            sampled_distance = np.geomspace(min_dis, max_dis, dis_grid_count)
+
+            for dis_count, dis in enumerate(sampled_distance):
+                
+                results = [] # Inference result of one sequence
+                for i, (bh_state, inj_state) in enumerate(sequence):
+
+                    sequence_start = (i == 0)
+                    sequence_end = (i == (len(sequence) - 1))
+
+                    # Sample orientation and sky location
+                    padded_ccsne = projector(
+                        time = signals_dict[key][0],
+                        quad_moment = signals_dict[key][1],
+                        ori_theta=np.zeros(stride_batch_size),
+                        ori_phi=np.zeros(stride_batch_size),
+                        dec=np.zeros(stride_batch_size),
+                        psi=np.zeros(stride_batch_size),
+                        phi=np.zeros(stride_batch_size),
+                    )
+
+                    # Sample start from the middle of the padded CCSN since no additainl time shift applied
+                    ccsne = padded_ccsne[:,:,3072:3072 + int(kernel_length * sample_rate)] / dis
+
+                    # Can be replace by reshape ccsne and add the two array.
+                    for inj_idx, ccsn in enumerate(ccsne):
+
+                        inj_start = int((one_side_pad_length + inj_idx) * sample_rate)
+                        inj_end = inj_start + kernel_size
+                        inj_state[:, inj_start: inj_end] += ccsn  
+
+                    
+                    client.infer(
+                        np.stack([bh_state, inj_state]),
+                        request_id=i,
+                        sequence_id=sequence_id + 1 + dis_grid_count * key_idx + dis_count,
+                        sequence_start=sequence_start,
+                        sequence_end=sequence_end,
+                    )
+
+                    result = client.get()
+                    while result is None:
+                        result = client.get()
+                    results.append(result[0])
+                    
+                    # One sequence ends leave the sequence loop
+                # For each Distance, of each CCSN template we save one file
+                
+                results = np.stack(results)
+                key_name = f"{key.replace('/', '_')}/DIS_{dis:05.1f}"
+                saving_dir = Path(f"../../inference_INJ_result/{key.replace('/', '_')}")
+                saving_dir.mkdir(parents=True, exist_ok=True)
+                result_file = saving_dir / f"Inj_sequence_{sequence_id}.h5"
+                logging.info(f"Collecting result to {result_file.resolve()}")
+
+                with h5py.File(result_file, "a") as f:
+                    f.create_dataset(key_name, data=results)
+
+if __name__ == "__main__":
+    
+    parser = ArgumentParser()
+    parser.add_argument("--config", action=ActionConfigFile)
+    parser.add_function_arguments(run_infer)
+
+    args = parser.parse_args()
+    args = args.as_dict()
+    
+    run_infer(**args)
+    

--- a/gwak/deploy/poetry.lock
+++ b/gwak/deploy/poetry.lock
@@ -2021,6 +2021,20 @@ files = [
 ]
 
 [[package]]
+name = "ratelimiter"
+version = "1.2.0.post0"
+description = "Simple python rate limiting object"
+optional = false
+python-versions = "*"
+files = [
+    {file = "ratelimiter-1.2.0.post0-py3-none-any.whl", hash = "sha256:a52be07bc0bb0b3674b4b304550f10c769bbb00fead3072e035904474259809f"},
+    {file = "ratelimiter-1.2.0.post0.tar.gz", hash = "sha256:5c395dcabdbbde2e5178ef3f89b568a3066454a6ddc223b76473dac22f89b4f7"},
+]
+
+[package.extras]
+test = ["pytest (>=3.0)", "pytest-asyncio"]
+
+[[package]]
 name = "requests"
 version = "2.32.3"
 description = "Python HTTP for Humans."
@@ -2499,4 +2513,4 @@ testing = ["coverage[toml]", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.12"
-content-hash = "642b9cefe0adde0e97d8cc5e4bd98b5b6063e9404e35f55da5b430cbc3700364"
+content-hash = "0c7689e0a155b326afe9b89b420d681920e3c9329dab2719e660c94f8dd392e7"

--- a/gwak/deploy/pyproject.toml
+++ b/gwak/deploy/pyproject.toml
@@ -24,6 +24,7 @@ psutil = "^6.1.1"
 h5py = "^3.12.1"
 tqdm = "^4.67.1"
 torch = "^2.6.0"
+ratelimiter = "^1.2.0.post0"
 
 [[tool.poetry.source]]
 name = "torch"

--- a/gwak/train/configs/bbh.yaml
+++ b/gwak/train/configs/bbh.yaml
@@ -10,7 +10,7 @@ trainer:
   strategy: ddp_find_unused_parameters_true
   logger:
     class_path: lightning.pytorch.loggers.WandbLogger
-  max_epochs: 10
+  max_epochs: 2
   check_val_every_n_epoch: 1
   accumulate_grad_batches: 1
 ckpt_path: null

--- a/gwak/train/configs/white_noise_burst.yaml
+++ b/gwak/train/configs/white_noise_burst.yaml
@@ -10,7 +10,7 @@ trainer:
   strategy: ddp_find_unused_parameters_true
   logger:
     class_path: lightning.pytorch.loggers.WandbLogger
-  max_epochs: 10
+  max_epochs: 2
   check_val_every_n_epoch: 1
   accumulate_grad_batches: 1
 ckpt_path: null
@@ -41,8 +41,8 @@ data:
         psd_length: 64
         fduration: 1
         fftlength: 2
-        batch_size: 8
-        batches_per_epoch: 8
+        batch_size: 4
+        batches_per_epoch: 4
         num_workers: 5
         prior: gwak.data.prior.WhiteNoiseBurstBBC
         waveform:

--- a/gwak/train/dataloader.py
+++ b/gwak/train/dataloader.py
@@ -544,7 +544,7 @@ class AugmentationSignalDataloader(GwakBaseDataloader):
             return batch
 
 
-class BBHDataloader(AugmentationSignalDataloader):
+class BBHDataloader(SignalDataloader):
 
     def __init__(
         self,

--- a/gwak/train/models.py
+++ b/gwak/train/models.py
@@ -37,14 +37,14 @@ class ModelCheckpoint(pl.callbacks.ModelCheckpoint):
             arch=pl_module.model, 
             metric=pl_module.metric
         )
-        
+        module.model.eval()
         # Modifiy these to read the last training/valdation data 
         # to acess the input shape. 
         # X = torch.randn(1, 200, 2) # GWAK 1
         X = torch.randn(1, 2, 200) # GWAK 2
 
-        trace = torch.jit.trace(module.model.to("cpu"), X.to("cpu"))
-
+        # trace = torch.jit.trace(module.model.to("cpu"), X.to("cpu"))
+        trace = torch.jit.script(module.model.to("cpu"))
         save_dir = trainer.logger.log_dir or trainer.logger.save_dir
 
         with open(os.path.join(save_dir, "model_JIT.pt"), "wb") as f:

--- a/gwak/train/train.smk
+++ b/gwak/train/train.smk
@@ -49,4 +49,4 @@ rule train:
 
 rule train_all:
     input:
-        expand(rules.train.log, datatype=['white_noise_burst', 'kinkkink', 'gaussian', 'cusp'])
+        expand(rules.train.log, datatype=['bbh'])

--- a/gwak/train/train.smk
+++ b/gwak/train/train.smk
@@ -49,4 +49,4 @@ rule train:
 
 rule train_all:
     input:
-        expand(rules.train.log, datatype=['bbh'])
+        expand(rules.train.log, datatype=['white_noise_burst'])


### PR DESCRIPTION
The original export model will aggregate snapshot data to the memory if we inject signals to the snapshot strain data, then the whiten-PSD will include frequency information of the injected waveform, causing the input data to whiten in the wrong way. 

    * Model saving method (Include logical condition e.g. for loop and if loop saving)

    * Export method (Include second channel for PSD aggregation)

    * Add CCSN injection function to triton execution end. (Not totally functional yet. )